### PR TITLE
Add i18n domains for Cofacts website

### DIFF
--- a/g0v.tw/cofacts.g0v.tw.json
+++ b/g0v.tw/cofacts.g0v.tw.json
@@ -6,6 +6,18 @@
                 "139.162.87.253"
             ]
         ],
+        "zh.cofacts.g0v.tw": [
+            [
+                "CNAME",
+                "cofacts.g0v.tw"
+            ]
+        ],
+        "en.cofacts.g0v.tw": [
+            [
+                "A",
+                "cofacts.g0v.tw"
+            ]
+        ],
         "cofacts-api.g0v.tw": [
             [
                 "A",


### PR DESCRIPTION
As title
Cofacts website is going to have i18n support. While the original domain will use `Accept-language` to detect language, we reserve two locale-specific domains so that users will be able to force domains.