### PR TITLE
Update summit2020.g0v.tw.json

### DIFF
--- a/g0v.tw/summit2020.g0v.tw.json
+++ b/g0v.tw/summit2020.g0v.tw.json
@@ -17,6 +17,34 @@
                 "A",
                 "35.194.129.213"
             ]
+        ],
+        "summit2020.g0v.tw":[
+            [
+                "TXT",
+                "v=spf1 include:mailgun.org ~all"
+            ],
+            [
+                "MX",
+                "mxa.mailgun.org"
+                10
+            ],
+            [
+                "MX",
+                "mxb.mailgun.org",
+                10
+            ]
+        ],
+        "email.summit2020.g0v.tw":[
+            [
+                "CNAME",
+                "mailgun.org"
+            ]
+        ],
+        "smtp._domainkey.summit2020.g0v.tw":[
+            [
+                "TXT",
+                "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+XjeSPX7bOkN0BBOh3R++E3l88ABjcMj8CNNXSAcXxdqKVvUSBQUdkdm9unU3gN64lACkbG8DdTBdwakthVb8kXEL3y0AHrGvhV2yRbWxRLWmY/7vkTX5M6YvqHVG2WQYDlpMXYKvIU04WjCUKCpbJuPAcxk9KxMIezcLHAELDwIDAQAB"
+            ]
         ]
     },
     "repository": "https://github.com/g0v/summit_proposal",


### PR DESCRIPTION
加入 mx record，會使用 mailgun 來寄信，用於討論區有新回應時寄信給討論串內的使用者。

<img width="1411" alt="螢幕快照 2020-07-05 下午6 18 39" src="https://user-images.githubusercontent.com/3148726/86530531-072a6680-beec-11ea-8dad-0dc59f9fbec8.png">

1. 主要聯絡人: howard, slack id @howard。
2. 申請 domain record: 在原本 summit2020.g0v.tw 上新增TXT, MX, CNAME，皆為驗證 mailgun 使用。
3. Repos:

Stage URL:
前端: https://g0v.github.io/summit2020
後端: https://api.summit2020.pre-stage.cc
討論區: https://discuss.summit2020.pre-stage.cc

Repository URL:
前端: https://github.com/g0v/summit_proposal
討論區: 用 nodebb 架設，https://github.com/NodeBB/NodeBB
後台部分建議等投稿結束後再補上
