### PR TITLE
Create link shortener for New Orleans community group under g0v.us domain

### DIFF
--- a/g0v.us/link.sam.nola.g0v.us.json
+++ b/g0v.us/link.sam.nola.g0v.us.json
@@ -1,0 +1,14 @@
+{
+    "domains": {
+        "link.sam.nola.g0v.us": [
+            [
+                "CNAME",
+                "cname.short.io"
+            ]
+        ]
+    },
+    "repository": "https://docs.google.com/document/d/1KQLnm2nvWvlzYiPZuf4xbhEcB-MY5Rc8tfQhPDuol0U/edit",
+    "maintainer": [
+        "patcon"
+    ]
+}


### PR DESCRIPTION
Hi! I'm working with a grassroots group trying to create a land trust in new orleans. I'm looking to introduce people (indirectly) to g0v ways of working. I'm helping them do transparent note-taking, and was hoping to set up a link shortener to make sharing resources easier within our group of 30 ppl.

New Orleans government websites are at nola.gov, so the nola.g0v.us domain name could have wider utility over here, if others want to start using it :)

Thanks for considering!