### PR TITLE
更新 summit.g0v.tw 的 DMARC 設定

### DIFF
--- a/g0v.tw/summit.g0v.tw.json
+++ b/g0v.tw/summit.g0v.tw.json
@@ -35,10 +35,28 @@
                 "v=spf1 a mx include:_spf.elasticemail.com include:sparkpostmail.com ~all"
             ]
         ],
+        "_dmarc.summit.g0v.tw": [
+            [
+                "TXT",
+                "v=DMARC1; p=none;"
+            ]
+        ],
         "api._domainkey.summit.g0v.tw": [
             [
                 "TXT",
                 "k=rsa;t=s;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCbmGbQMzYeMvxwtNQoXN0waGYaciuKx8mtMh5czguT4EZlJXuCt6V+l56mmt3t68FEX5JJ0q4ijG71BGoFRkl87uJi7LrQt1ZZmZCvrEII0YO4mp8sDLXC8g1aUAoi8TJgxq2MJqCaMyj5kAm3Fdy2tzftPCV\/lbdiJqmBnWKjtwIDAQAB"
+            ]
+        ],
+        "k2._domainkey.summit.g0v.tw": [
+            [
+                "CNAME",
+                "dkim2.mcsv.net"
+            ]
+        ],
+        "k3._domainkey.summit.g0v.tw": [
+            [
+                "CNAME",
+                "dkim3.mcsv.net"
             ]
         ],
         "r6w5sa4fbgiz.summit.g0v.tw": [


### PR DESCRIPTION
**相關資料：** 參考 [Slack 討論串](https://g0v-tw.slack.com/archives/CF3JH3H1C/p1715349159739019)。

**理由：** 由於今年 Summit 使用的電子報系統 Mailchimp 建議進行網域驗證，以便未來投遞的信件能更順利送達，因此 Summit 宣傳組想麻煩協助進行網域驗證。

**新增內容：** MailChimp 系統的 DKIM 與 DMARC 紀錄資訊。

**目前 MailChimp 管理者：** g0v Summit 宣傳組（媒體小組長 YC 、阿敏，以及組長 @RSChiang）