### PR TITLE
Change Open165 repo and Cloudflare setup

### DIFF
--- a/g0v.tw/165.g0v.tw.json
+++ b/g0v.tw/165.g0v.tw.json
@@ -3,11 +3,11 @@
         "165.g0v.tw": [
             [
                 "CNAME",
-                "open165.pages.dev"
+                "site-9hb.pages.dev"
             ]
         ]
     },
-    "repository": "https://github.com/cofacts/open165",
+    "repository": "https://github.com/open165/site",
     "maintainer": [
         "johnson@cofacts.tw"
     ]


### PR DESCRIPTION
I have moved the repo from https://github.com/cofacts/open165 to https://github.com/open165/site .

However, I [have to reconnect](https://community.cloudflare.com/t/how-to-change-repo-connected-to-page/332796/5) Cloudflare Pages 's Github connection to a different Cloudflare project, which requires me to update the CNAME record.