### PR TITLE
Fix CNAME for gh-pages

### DIFF
--- a/g0v.tw/8bit.g0v.tw.json
+++ b/g0v.tw/8bit.g0v.tw.json
@@ -3,7 +3,7 @@
         "8bit.g0v.tw": [
             [
                 "CNAME",
-                "g0v.github.com"
+                "g0v.github.io"
             ]
         ]
     },

--- a/g0v.tw/dev.g0v.tw.json
+++ b/g0v.tw/dev.g0v.tw.json
@@ -3,7 +3,7 @@
         "dev.g0v.tw": [
             [
                 "CNAME",
-                "g0v.github.com"
+                "g0v.github.io"
             ]
         ]
     },

--- a/g0v.tw/realprice.g0v.tw.json
+++ b/g0v.tw/realprice.g0v.tw.json
@@ -3,7 +3,7 @@
         "realprice.g0v.tw": [
             [
                 "CNAME",
-                "g0v.github.com"
+                "g0v.github.io"
             ]
         ]
     },

--- a/g0v.tw/summit.g0v.tw.json
+++ b/g0v.tw/summit.g0v.tw.json
@@ -3,7 +3,7 @@
         "summit.g0v.tw": [
             [
                 "CNAME",
-                "g0v.github.com"
+                "g0v.github.io"
             ],
             [
                 "MX",


### PR DESCRIPTION
Discussion: https://g0v-slack-archive.g0v.ronny.tw/index/channel/CF3JH3H1C#ts-1737379730.345679

According to [Github documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain):
> If you want to use the subdomain another.example.com for your organization site, create a CNAME record that points another.example.com to <organization>.github.io. The CNAME record should always point to <user>.github.io or <organization>.github.io, excluding the repository name.

The CNAME records pointing to g0v.github`.com` are incorrect and should be fixed so that HTTP requests can be directed correctly to the gh-pages.