### PR TITLE
新增 Summit 外部申訴委員轉信信箱

### DIFF
--- a/g0v.tw/summit.g0v.tw.json
+++ b/g0v.tw/summit.g0v.tw.json
@@ -72,7 +72,8 @@
             {"name": "sponsorship", "target": "g0v-summit-2026-sponsorship at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
             {"name": "media", "target": "g0v-summit-2026-media at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
             {"name": "programming", "target": "g0v-summit-2026-programming at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
-            {"name": "coc", "target": "g0v-summit-2026-coc at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/coc-procedure"}
+            {"name": "coc", "target": "g0v-summit-2026-coc at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/coc-procedure"},
+            {"name": "keeper", "target": "tifflin2022 at gmail.com", "document": "https://g0v.hackmd.io/@summit2026/coc-procedure"}
         ]
     },
     "repository": "https://github.com/g0v/summit.g0v.tw",


### PR DESCRIPTION
因應 Summit 訂定[社群守則申訴流程](https://g0v.hackmd.io/@summit2026/coc-procedure)，特別額外設定社群守則申訴小組的轉信信箱 `keeper@summit 點 g0v.tw`。ᶘ ᵒᴥᵒᶅ