### PR TITLE
新增 wallet@summit 轉信信箱

### DIFF
--- a/g0v.tw/summit.g0v.tw.json
+++ b/g0v.tw/summit.g0v.tw.json
@@ -73,6 +73,7 @@
             {"name": "sponsorship", "target": "g0v-summit-2026-sponsorship at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
             {"name": "media", "target": "g0v-summit-2026-media at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
             {"name": "programming", "target": "g0v-summit-2026-programming at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
+            {"name": "wallet", "target": "g0v-summit-2026-wallet at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/portal#%E6%AC%8A%E9%99%90%E7%AE%A1%E7%90%86%E6%96%B9%E5%BC%8F"},
             {"name": "coc", "target": "g0v-summit-2026-coc at googlegroups.com", "document": "https://g0v.hackmd.io/@summit2026/coc-procedure"},
             {"name": "keeper", "target": "tifflin2022 at gmail.com", "document": "https://g0v.hackmd.io/@summit2026/coc-procedure"}
         ]


### PR DESCRIPTION
用以收發 Summit 數位皮夾實用專案開發過程的聯繫信件！

還請 @ronnywang 協助開設了～